### PR TITLE
flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1651214382,
+        "narHash": "sha256-rOpW5ZZ+RbUsYoOx8jKjcGcHllBiKqVFLTARlOu96tc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd956a5acab3b6ae370facb3066cf400d575ff44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "spack": "spack"
+      }
+    },
+    "spack": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651199899,
+        "narHash": "sha256-GSqn16+3aLGq3phHQp1kGdlQraGO2UJ12yqL5Dfr9Fs=",
+        "owner": "spack",
+        "repo": "spack",
+        "rev": "8a6b73bb2cb285904398224e743e405cea87dcce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "spack",
+        "repo": "spack",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,120 @@
+{
+  description = "Flake for NixPACK";
+
+  inputs.spack = { url="github:spack/spack"; flake=false; };
+  #inputs.spack = { url="github:flatironinstitute/spack/fi-nixpack"; flake=false; };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+  outputs = inputs: let
+    nixpkgsFor = system: import inputs.nixpkgs {
+      inherit system;
+      config = {
+        replaceStdenv = import ./nixpkgs/stdenv.nix;
+        allowUnfree = true;
+        cudaSupport = true;
+      };
+      overlays = [(import ./nixpkgs/overlay.nix)];
+    };
+
+    nixosPacks = system: let
+      pkgs = nixpkgsFor system;
+      gccWithFortran = pkgs.wrapCC (pkgs.gcc.cc.override {
+        langFortran = true;
+      });
+    in inputs.self.lib.packs {
+      inherit system;
+      os = "nixos21";
+      global.verbose = "true";
+      spackConfig.config.source_cache="/tmp/spack_cache";
+      spackPython = "${pkgs.python3}/bin/python3";
+      spackEnv   = {
+        # pure environment PATH
+        PATH=/*"/run/current-system/sw/bin:"
+            +*/inputs.nixpkgs.lib.concatStringsSep ":"
+            (builtins.map (x: "${x}/bin")
+            [
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.gnumake
+              pkgs.gnutar
+              pkgs.gzip
+              pkgs.bzip2
+              pkgs.xz
+              pkgs.gawk
+              pkgs.gnused
+              pkgs.gnugrep
+              pkgs.glib
+              pkgs.binutils.bintools # glib: locale
+              pkgs.patch
+              pkgs.texinfo
+              pkgs.diffutils
+              pkgs.pkgconfig
+              pkgs.gitMinimal
+              pkgs.findutils
+            ]);
+        #PATH="/run/current-system/sw/bin:${pkgs.gnumake}/bin:${pkgs.binutils.bintools}/bin";
+        LOCALE_ARCHIVE="/run/current-system/sw/lib/locale/locale-archive";
+        LIBRARY_PATH=/*"/run/current-system/sw/bin:"
+            +*/inputs.nixpkgs.lib.concatStringsSep ":"
+            (builtins.map (x: "${x}/lib")
+            [
+              (inputs.nixpkgs.lib.getLib pkgs.binutils.bintools) # ucx (configure fails) libbfd not found
+	    ]);
+      };
+
+      package = {
+        compiler = { name="gcc"; extern=gccWithFortran; version=gccWithFortran.version; };
+        perl = { extern=pkgs.perl; version=pkgs.perl.version; };
+        openssh = { extern=pkgs.openssh; version=pkgs.openssh.version; };
+        openssl = { extern=pkgs.symlinkJoin { name="openssl"; paths = [ pkgs.openssl.all ]; }; version=pkgs.openssl.version; };
+        openmpi = {
+          version = "4.1";
+          variants = {
+            fabrics = {
+              none = false;
+              ucx = true;
+            };
+            schedulers = {
+              none = false;
+              slurm = false;
+            };
+            pmi = false;
+            pmix = false;
+            static = false;
+            thread_multiple = true;
+            legacylaunchers = true;
+          };
+        };
+      };
+      repoPatch = {
+        dyninst = spec: old: {
+          patches = [ ./patch/dyninst-nixos.patch ];
+        };
+        openmpi = spec: old: {
+          build = {
+            setup = ''
+              configure_args = pkg.configure_args()
+              if spec.satisfies("~pmix"):
+                if '--without-mpix' in configure_args: configure_args.remove('--without-pmix')
+              pkg.configure_args = lambda: configure_args
+            '';
+          };
+        };
+      };
+    };
+  in {
+    lib = (import packs/lib.nix) // {
+      packs = {
+        ...
+      }@args: import ./packs ({
+        inherit (inputs) spack nixpkgs;
+      } // args);
+    };
+
+
+    packages.x86_64-linux = nixosPacks "x86_64-linux";
+
+    defaultPackage.x86_64-linux = inputs.self.packages.x86_64-linux.hello;
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,6 @@
       } // args);
     };
 
-
     packages.x86_64-linux = nixosPacks "x86_64-linux";
 
     defaultPackage.x86_64-linux = inputs.self.packages.x86_64-linux.hello;

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,15 +1,10 @@
 { system ? builtins.currentSystem
 , target ? builtins.head (builtins.split "-" system)
-, src ? {}
+, nixpkgs
 , overlays ? []
 }:
 
 let
-
-nixpkgs = fetchGit ({
-  url = "https://github.com/NixOS/nixpkgs";
-  ref = "master";
-} // src);
 
 args = {
   localSystem = {

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -5,11 +5,13 @@
 }:
 
 let
+# gcc arch is x64-64
+target_ = builtins.replaceStrings ["x86_64"] ["x86-64"] target;
 
 args = {
   localSystem = {
     inherit system;
-    gcc = { arch = target; };
+    gcc = { arch = target_; };
   };
   config = {
     replaceStdenv = import ./stdenv.nix;

--- a/nixpkgs/overlay.nix
+++ b/nixpkgs/overlay.nix
@@ -18,6 +18,10 @@ with pkgs;
     doCheck = false; # failure
   });
 
+  libffi = libffi.overrideAttrs (old: {
+    doCheck = false; # failure
+  });
+
   coreutils = (coreutils.override {
     autoreconfHook = null; # workaround nixpkgs #144747
   }).overrideAttrs (old: {

--- a/nixpkgs/overlay.nix
+++ b/nixpkgs/overlay.nix
@@ -33,7 +33,66 @@ with pkgs;
     doInstallCheck = false;
   });
 
-  git = git.overrideAttrs (old: {
+  # `fetchurl' downloads a file from the network.
+  fetchurl = if stdenv.buildPlatform != stdenv.hostPlatform
+    then buildPackages.fetchurl # No need to do special overrides twice,
+    else makeOverridable (import (pkgs.path + "/pkgs/build-support/fetchurl")) {
+      inherit lib stdenvNoCC buildPackages;
+      inherit cacert;
+      curl = buildPackages.curlMinimal.override (old: rec {
+        # break dependency cycles
+        fetchurl = stdenv.fetchurlBoot;
+        zlib = buildPackages.zlib.override { fetchurl = stdenv.fetchurlBoot; };
+        pkg-config = buildPackages.pkg-config.override (old: {
+          pkg-config = old.pkg-config.override {
+            fetchurl = stdenv.fetchurlBoot;
+          };
+        });
+        perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; inherit zlib; };
+        openssl = buildPackages.openssl.override {
+          fetchurl = stdenv.fetchurlBoot;
+          buildPackages = {
+            coreutils = (buildPackages.coreutils.override rec {
+              fetchurl = stdenv.fetchurlBoot;
+              inherit perl;
+              xz = buildPackages.xz.override { fetchurl = stdenv.fetchurlBoot; };
+              gmp = null;
+              aclSupport = false;
+              attrSupport = false;
+              autoreconfHook = null; # workaround nixpkgs #144747
+              texinfo = null;
+            }).overrideAttrs (_: {
+              preBuild = "touch Makefile.in"; # avoid automake
+            });
+            inherit perl;
+          };
+          inherit perl;
+        };
+        libssh2 = buildPackages.libssh2.override {
+          fetchurl = stdenv.fetchurlBoot;
+          inherit zlib openssl;
+        };
+        # On darwin, libkrb5 needs bootstrap_cmds which would require
+        # converting many packages to fetchurl_boot to avoid evaluation cycles.
+        # So turn gssSupport off there, and on Windows.
+        # On other platforms, keep the previous value.
+        gssSupport =
+          if stdenv.isDarwin || stdenv.hostPlatform.isWindows
+            then false
+            else old.gssSupport or true; # `? true` is the default
+        libkrb5 = buildPackages.libkrb5.override {
+          fetchurl = stdenv.fetchurlBoot;
+          inherit pkg-config perl openssl;
+          keyutils = buildPackages.keyutils.override { fetchurl = stdenv.fetchurlBoot; };
+        };
+        nghttp2 = buildPackages.nghttp2.override {
+          fetchurl = stdenv.fetchurlBoot;
+          inherit pkg-config;
+          enableApp = false; # curl just needs libnghttp2
+          enableTests = false; # avoids bringing `cunit` and `tzdata` into scope
+        };
+      });
+    };  git = git.overrideAttrs (old: {
     doCheck = false; # failure
     doInstallCheck = false; # failure
   });
@@ -83,3 +142,4 @@ with pkgs;
       "-DEMBREE_ISA_SSE42=OFF"];
   });
 }
+

--- a/patch/dyninst-nixos.patch
+++ b/patch/dyninst-nixos.patch
@@ -1,0 +1,20 @@
+diff --git a/scripts/dynsysname b/scripts/dynsysname
+index 6906fb224..ce385e046 100755
+--- a/scripts/dynsysname
++++ b/scripts/dynsysname
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ 
+ P=$1
+ 
+diff --git a/scripts/sysname b/scripts/sysname
+index 16f540483..dccd3e677 100755
+--- a/scripts/sysname
++++ b/scripts/sysname
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ # $Id: sysname,v 1.6 2005/08/09 16:13:16 gquinn Exp $
+ # Attempt to guess a canonical system name.
+ #   Copyright (C) 1992, 1993, 1994, 1995 Free Software Foundation, Inc.


### PR DESCRIPTION
This introduces flake support to nixpack:
It exposes `lib.packs` and the spack packages behind pkgs attribute (bootstrapped with the default gcc compiler from nixpkgs).

````sh
nix build .#pkgs.mpileaks --impure --option sandbox false -L
````

As SPACK need to be patched, it is imported from flatironinstitute fork.
As nixpkgs need also to be patched [1], it is imported from my fork.

[1] https://github.com/NixOS/nixpkgs/pull/144747