### PR TITLE
versionIsConcrete: fix match to not always return null

### DIFF
--- a/packs/lib.nix
+++ b/packs/lib.nix
@@ -90,7 +90,7 @@ rec {
       "2" = s1;
     }.${toString (versionCompare s1 s2)};
 
-  versionIsConcrete = v: v != null && match "[:,]" v == null;
+  versionIsConcrete = v: v != null && match ".*([:,]).*" v == null;
 
   versionRange = v: let
       s = splitRegex ":" v;


### PR DESCRIPTION
`builtins.match "[:,]" "what-ever-version:"` always returns `null`

This patch fixes the regex to return a non-empty list if the version contains either `:` or `,`.