### PR TITLE
modules: make lmod MODULE_PATH working with compiler_spec

### DIFF
--- a/spack/modules.py
+++ b/spack/modules.py
@@ -83,6 +83,9 @@ class ModSpec:
             self.pkg = p.get('pkg', None)
         if self.pkg:
             self.spec = nixpack.NixSpec.get(self.pkg)
+            if self.spec.nixspec['compiler_spec'] != self.spec.nixspec['name']:
+                # override name with the compiler_spec (special nixpack case for compiler class)
+                self.spec.name = str(self.spec.as_compiler.name)
         else:
             self.spec = FakeSpec(p)
 


### PR DESCRIPTION
With this patch, loading `intel` or `oneapi` module populates MODULEPATH for hierarchical module loading.