### PR TITLE
modules.py: spack.package.PackageBase -> spack.package_base.PackageBase

### DIFF
--- a/spack/modules.py
+++ b/spack/modules.py
@@ -20,7 +20,7 @@ core_specs = modconf.setdefault('core_specs', [])
 
 cls = spack.modules.module_types[modtype]
 
-class FakePackage(spack.package.PackageBase):
+class FakePackage(spack.package_base.PackageBase):
     extendees = ()
     provided = {}
 


### PR DESCRIPTION
Fix usage of modules.py.