### PR TITLE
extern: set external_modules with new modules attribute

### DIFF
--- a/packs/default.nix
+++ b/packs/default.nix
@@ -171,6 +171,7 @@ lib.fix (packs: with packs; {
     , patches ? []
     , depends ? {}
     , extern ? null
+    , modules ? null
     , provides ? {}
     , tests ? false
     , fixedDeps ? false
@@ -182,7 +183,7 @@ lib.fix (packs: with packs; {
     , verbose ? false # only used by builder
     } @ prefs:
     prefs // {
-      inherit version variants patches depends extern tests provides fixedDeps target paths;
+      inherit version variants patches depends extern modules tests provides fixedDeps target paths;
       resolver = deptype: name: let r = lib.applyOptional (lib.applyOptional resolver deptype) name; in
         if builtins.isFunction r then r
         else (lib.coalesce r packs).getResolver name;
@@ -311,7 +312,7 @@ lib.fix (packs: with packs; {
           prefs = fillPrefs pprefs;
           spec = {
             inherit (desc) name namespace provides;
-            inherit (prefs) extern tests;
+            inherit (prefs) extern modules tests;
             target = spackTarget prefs.target;
             paths = desc.paths // prefs.paths;
             version = if prefs.extern != null && lib.versionIsConcrete prefs.version

--- a/packs/lib.nix
+++ b/packs/lib.nix
@@ -205,6 +205,7 @@ rec {
         patches = scalar;
         depends = mergeWith prefsUpdate;
         extern = scalar;
+        modules = scalar;
         tests = scalar;
         fixedDeps = scalar;
         resolver = scalar;
@@ -231,6 +232,7 @@ rec {
         patches = a: b: a ++ b;
         depends = mergeWith prefsIntersect;
         extern = scalar;
+        modules = scalar;
         tests = scalar;
         fixedDeps = scalar;
         resolver = scalar;
@@ -255,7 +257,7 @@ rec {
   /* traverse all dependencies of given package(s) that satisfy pred recursively and return them as a list (in bredth-first order) */
   findDeps = pred:
     let
-      adddeps = s: pkgs: add s 
+      adddeps = s: pkgs: add s
         (foldl' (deps: p:
           (deps ++ filter (d: d != null && ! (elem d s) && ! (elem d deps) && pred d)
             (attrValues p.spec.depends)))

--- a/spack/nixpack.py
+++ b/spack/nixpack.py
@@ -230,6 +230,7 @@ class NixSpec(spack.spec.Spec):
         self._set_architecture(target=nixspec.get('target', basetarget), platform=platform, os=archos)
         self.prefix = prefix
         self.external_path = nixspec['extern']
+        self.external_modules = nixspec.get('modules',None)
         if self.external_path:
             assert self.external_path == prefix, f"{self.name} extern {nixspec['extern']} doesn't match prefix {prefix}"
         else:


### PR DESCRIPTION
This path allow to define extern packages that require a modulefile to be loaded.

Maybe an `environment` attribute could be usefull as well.