### PR TITLE
add common environment variables to cuda module

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -897,6 +897,15 @@ cuda_arch = { none = false; } // builtins.listToAttrs
   (map (a: { name = a; value = true; })
     (if builtins.isString cudaarch then lib.splitRegex "," cudaarch else cudaarch));
 
+format_cudaarch = (dot: sep: builtins.concatStringsSep sep
+  (map (v: let L = builtins.stringLength v; in
+      builtins.concatStringsSep dot
+        [ (builtins.substring 0 (L - 1) v) (builtins.substring (L - 1) 1 v) ]
+      )
+    (lib.splitRegex "," cudaarch)
+  )
+);
+
 mkSkylake = base: base.withPrefs {
   global = {
     target = "skylake_avx512";
@@ -1992,6 +2001,18 @@ mods = corePacks.modules {
       prerequisites = "direct";
       filter = {
         environment_blacklist = ["CC" "FC" "CXX" "F77"];
+      };
+    };
+    cuda = {
+      environment = {
+        set = {
+          # set target arches for common cuda software
+          TORCH_CUDA_ARCH_LIST = format_cudaarch "." ";";  # 7.0;8.0
+          TCNN_CUDA_ARCHITECTURES = format_cudaarch "" ";";  # 70;80
+          HOROVOD_BUILD_CUDA_CC_LIST = format_cudaarch "" ",";  # 70,80
+
+          HOROVOD_CUDA_HOME = "{prefix}";
+        };
       };
     };
     intel-mkl = {


### PR DESCRIPTION
Adds environment variables used by common software packages when building against CUDA.  They each have slightly different formats.

The `format_cudaarch` lambda assumes only one digit of minor version, so "100" becomes "10.0".

Here are the variables and example values:
```bash
# https://github.com/pytorch/pytorch/blob/adfbd831cf59111c3d3a4a50ba6372bba94b63d1/setup.py#L118
TORCH_CUDA_ARCH_LIST='7.0;8.0'

#https://github.com/NVlabs/tiny-cuda-nn/blob/6a835fd7ed8f76cd7ac0a9744b79da8b67e17c14/bindings/torch/setup.py#L22
TCNN_CUDA_ARCHITECTURES='70;80'

#https://github.com/horovod/horovod/blob/512928d51720dc03beb77497c9a5883c3c61c87a/cmake/build_utils.py#L95
HOROVOD_BUILD_CUDA_CC_LIST='70,80'

#https://github.com/horovod/horovod/blob/512928d51720dc03beb77497c9a5883c3c61c87a/cmake/build_utils.py#L80
HOROVOD_CUDA_HOME=$CUDA_HOME
```