### PR TITLE
astropy 5 and healpy

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -512,8 +512,7 @@ corePacks = import ../packs {
     };
     psm = bootstrapPacks.pkgs.psm; # needs old gcc
     py-astropy = {
-      # 5 has broken build (copy permissions)
-      version = "4";
+      version = "5";
       depends = {
         py-cython = {
           version = "0.29.30";

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1627,6 +1627,7 @@ pkgStruct = {
         #py-einsum2
         py-emcee
         py-envisage #qt
+        py-healpy
         py-flask
         py-flask-socketio
         py-fusepy

--- a/fi/repo/packages/py-extension-helpers/_setup_helpers.py.patch
+++ b/fi/repo/packages/py-extension-helpers/_setup_helpers.py.patch
@@ -1,0 +1,20 @@
+diff --git a/extension_helpers/_setup_helpers.py b/extension_helpers/_setup_helpers.py
+index 7e766da..8636873 100644
+--- a/extension_helpers/_setup_helpers.py
++++ b/extension_helpers/_setup_helpers.py
+@@ -94,8 +94,13 @@ def get_extensions(srcdir='.'):
+     if len(ext_modules) > 0:
+         main_package_dir = min(packages, key=len)
+         src_path = os.path.join(os.path.dirname(__file__), 'src')
+-        shutil.copy(os.path.join(src_path, 'compiler.c'),
+-                    os.path.join(srcdir, main_package_dir, '_compiler.c'))
++        dst_file = os.path.join(srcdir, main_package_dir, '_compiler.c')
++        try:
++            # remove dst_file in case it exists but is read-only
++            os.remove(dst_file)
++        except FileNotFoundError:
++            pass
++        shutil.copy(os.path.join(src_path, 'compiler.c'), dst_file)
+         ext = Extension(main_package_dir + '.compiler_version',
+                         [os.path.join(main_package_dir, '_compiler.c')])
+         ext_modules.append(ext)

--- a/fi/repo/packages/py-extension-helpers/package.py
+++ b/fi/repo/packages/py-extension-helpers/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyExtensionHelpers(PythonPackage):
+    """The extension-helpers package includes convenience helpers to
+    assist with building Python packages with compiled C/Cython
+    extensions. It is developed by the Astropy project but is intended
+    to be general and usable by any Python package."""
+
+    homepage = "https://github.com/astropy/astropy-helpers"
+    pypi = "extension-helpers/extension-helpers-0.1.tar.gz"
+
+    version("1.0.0", sha256="ca1bfac67c79cf4a7a0c09286ce2a24eec31bf17715818d0726318dd0e5050e6")
+    version("0.1", sha256="ac8a6fe91c6d98986a51a9f08ca0c7945f8fd70d95b662ced4040ae5eb973882")
+
+    depends_on("python@3.6:", type=("build", "run"))
+    depends_on("py-setuptools@30.3:", type="build")
+
+    patch('_setup_helpers.py.patch')

--- a/fi/repo/packages/py-healpy/package.py
+++ b/fi/repo/packages/py-healpy/package.py
@@ -1,0 +1,19 @@
+from spack.package import *
+
+
+class PyHealpy(PythonPackage):
+    """healpy is a Python package to handle pixelated data on the sphere.
+    
+    This version links against the healpix package in the FI repo, rather
+    than spack's healpix-cxx.
+    """
+
+    homepage = "https://healpy.readthedocs.io/"
+    pypi = "healpy/healpy-1.16.2.tar.gz"
+
+    version("1.16.2", sha256="b7b9433152ff297f88fc5cc1277402a3346ff833e0fb7e026330dfac454de480")
+
+    depends_on("py-setuptools@3.2:", type="build")
+    depends_on("py-cython", type="build")
+    depends_on("py-numpy", type=("build","run"))
+    depends_on("healpix", type=("build","link","run"))


### PR DESCRIPTION
To get healpy to import, we decided to try to get astropy 5 working. To get that working, we had to patch `py-extension-helpers` to overwrite files, even if they're read only.  It's a pretty safe fix, so I'll probably submit a PR to `extension-helpers` too.

healpy passes its test suite; I'll let astropy's run overnight.