### PR TITLE
fi: add rockstar and rockstar-galaxies

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1504,6 +1504,20 @@ pkgStruct = {
       })
       #openssl
       pgplot
+      {
+        pkg = rockstar;
+        postscript = ''
+          whatis("Short description: Peter Behroozi's Rockstar (https://bitbucket.org/gfcstanford/rockstar)")
+          help([[Peter Behroozi's Rockstar (https://bitbucket.org/gfcstanford/rockstar)]])
+        '';
+      }
+      {
+        pkg = rockstar.withPrefs { version = "galaxies"; };
+        postscript = ''
+          whatis("Short description: Andrew Wetzel's rockstar-galaxies (https://bitbucket.org/awetzel/rockstar-galaxies)")
+          help([[Andrew Wetzel's rockstar-galaxies (https://bitbucket.org/awetzel/rockstar-galaxies)]])
+        '';
+      }
       ucx
     ] ++
     optMpiPkgs comp.packs

--- a/fi/repo/packages/rockstar/0001-Fix-to-solve-linking-problem-with-gcc-10.patch
+++ b/fi/repo/packages/rockstar/0001-Fix-to-solve-linking-problem-with-gcc-10.patch
@@ -1,0 +1,53 @@
+From 36ce9eea36eeda4c333acf56f8bb0d40ff0df2a1 Mon Sep 17 00:00:00 2001
+From: Peter Behroozi <peter@Peters-MacBook-Pro-3.local>
+Date: Sat, 4 Sep 2021 15:20:44 +0900
+Subject: [PATCH] Fix to solve linking problem with gcc-10
+
+---
+ client.c       | 2 +-
+ fun_times.h    | 2 +-
+ interleaving.h | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/client.c b/client.c
+index 5525eb9..cd4e1ff 100644
+--- a/client.c
++++ b/client.c
+@@ -764,7 +764,7 @@ void transfer_stuff(int64_t s, int64_t c, int64_t timestep) {
+ }
+ 
+ void do_projections(void) {
+-  int64_t i, j, idx, dir;
++  int64_t i, j, idx, dir=0;
+   assert(BOX_SIZE > 0);
+   for (i=0; i<num_proj; i++) {
+     prj[i].id = prq[i].id;
+diff --git a/fun_times.h b/fun_times.h
+index 0dd1355..10397cd 100644
+--- a/fun_times.h
++++ b/fun_times.h
+@@ -15,7 +15,7 @@ struct prev_bounds {
+   float bounds[6];
+ };
+ 
+-struct prev_bounds *p_bounds;
++extern struct prev_bounds *p_bounds;
+ extern int64_t prev_snap;
+ 
+ #define MAX_CORE_PARTICLES 10000
+diff --git a/interleaving.h b/interleaving.h
+index 1d3894b..1537887 100644
+--- a/interleaving.h
++++ b/interleaving.h
+@@ -18,7 +18,7 @@ struct bgroup {
+ 
+ extern int64_t num_new_bp;
+ extern struct bgroup *bg;
+-struct bgroup *final_bg;
++extern struct bgroup *final_bg;
+ extern int64_t num_bg_sets;
+ extern int64_t *bg_set_sizes;
+ extern int64_t *bg_set_indices;
+-- 
+2.35.1
+

--- a/fi/repo/packages/rockstar/package.py
+++ b/fi/repo/packages/rockstar/package.py
@@ -1,0 +1,88 @@
+# Adapted from Spack's built-in Rockstar
+
+from spack.package import *
+
+
+class Rockstar(MakefilePackage):
+    """The Rockstar halo finder"""
+
+    homepage = "https://bitbucket.org/gfcstanford/rockstar"    
+
+    # main repo
+    version("main.2021-09-04.36ce9e",
+        git = 'https://bitbucket.org/gfcstanford/rockstar.git',
+        commit = '36ce9eea36eeda4c333acf56f8bb0d40ff0df2a1',
+        preferred=True,
+    )
+    # awetzel's rockstar-galaxies fork
+    version("galaxies.2022-12-29.a9d865",
+        git = 'https://bitbucket.org/awetzel/rockstar-galaxies.git',
+        commit = 'a9d8653c0aabc1ba31646e504c2d37013ffd11d4',
+    )
+
+    variant("hdf5", description="HDF5 support", default=True)
+
+    depends_on("hdf5", when="+hdf5")
+    depends_on('libtirpc')
+
+    patch('0001-Fix-to-solve-linking-problem-with-gcc-10.patch',
+        when='@galaxies',
+    )
+
+    def patch(self):
+        oflags = ' '.join(self.extra_oflags())
+        filter_file(
+            r'^(OFLAGS\s*=[^#\n]*)',
+            rf'\1 {oflags}',
+            'Makefile',
+        )
+        filter_file(
+            r'(-D_BSD_SOURCE|-D_SVID_SOURCE)',
+            r'-D_DEFAULT_SOURCE',
+            'Makefile',
+        )
+        filter_file(
+            r'^CC\s*=.*',
+            r'',
+            'Makefile',
+        )
+
+    def extra_oflags(self):
+        return ['-ltirpc']
+
+    def install(self, spec, prefix):
+        # install the entire repo
+        # probably only the binaries will be used, though
+        install_tree('.', prefix)
+
+        mkdirp(prefix.bin)
+        mkdirp(prefix.lib)
+
+        util = ['util/bgc2_to_ascii',
+                'util/find_parents',
+                'util/finish_bgc2',
+                'util/subhalo_stats',
+                ]
+        for fn in util:
+            install(fn, prefix.bin)
+        
+        if '@galaxies' in spec:
+            install('rockstar-galaxies', prefix.bin)
+            install('librockstar-galaxies.so', prefix.lib)
+        else:
+            install('rockstar', prefix.bin)
+            install('librockstar.so', prefix.lib)
+
+    @property
+    def build_targets(self):
+        targets = [
+            'lib',
+            'bgc2',
+            'parents',
+            'substats'
+        ]
+        if '+hdf5' in self.spec:
+            targets += ['with_hdf5']
+        else:
+            targets += ['all']
+        return targets

--- a/fi/repo/packages/rockstar/package.py
+++ b/fi/repo/packages/rockstar/package.py
@@ -1,5 +1,7 @@
 # Adapted from Spack's built-in Rockstar
 
+import os
+
 from spack.package import *
 
 
@@ -53,7 +55,7 @@ class Rockstar(MakefilePackage):
     def install(self, spec, prefix):
         # install the entire repo
         # probably only the binaries will be used, though
-        install_tree('.', prefix)
+        install_tree('.', prefix.src)
 
         mkdirp(prefix.bin)
         mkdirp(prefix.lib)
@@ -64,14 +66,19 @@ class Rockstar(MakefilePackage):
                 'util/subhalo_stats',
                 ]
         for fn in util:
-            install(fn, prefix.bin)
+            install_link(join_path(prefix.src, fn),
+                         prefix.bin)
         
         if '@galaxies' in spec:
-            install('rockstar-galaxies', prefix.bin)
-            install('librockstar-galaxies.so', prefix.lib)
+            install_link(join_path(prefix.src, 'rockstar-galaxies'),
+                         prefix.bin)
+            install_link(join_path(prefix.src, 'librockstar-galaxies.so'),
+                         prefix.lib)
         else:
-            install('rockstar', prefix.bin)
-            install('librockstar.so', prefix.lib)
+            install_link(join_path(prefix.src, 'rockstar'),
+                        prefix.bin)
+            install_link(join_path(prefix.src, 'librockstar.so'),
+                         prefix.lib)
 
     @property
     def build_targets(self):
@@ -86,3 +93,7 @@ class Rockstar(MakefilePackage):
         else:
             targets += ['all']
         return targets
+
+def install_link(src, dst):
+    '''Install into `dst` dir via hard link'''
+    os.link(src, join_path(dst, os.path.basename(src)))


### PR DESCRIPTION
Adds the Rockstar halo finder, and the fork rockstar-galaxies. Available as `rockstar/main` and `rockstar/galaxies` in the modules.