### PR TITLE
fi: py-fitsio, music, globus, fgsl, dedalus, jupyterhub

### DIFF
--- a/fi/README.md
+++ b/fi/README.md
@@ -132,3 +132,6 @@ To do a release:
 2. Release should now show up as new `modules` version, which you can load to test.
 3. Update default symlink in /cm/shared/sw/lmod/modules/modules when ready.
 4. Run `fi/run modules` to update cache (after any change to modules).
+
+## Branches
+`fi` corresponds to the current modules set; `main` is the upcoming set.

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1523,6 +1523,7 @@ pkgStruct = {
       cfitsio
       cgal
       eigen
+      fgsl
       ffmpeg
       flexiblas
       gsl

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1691,14 +1691,14 @@ pkgStruct = {
             projection = "dedalus/{version}-py{^python.version}";
             postscript = ''
               depends_on("python-mpi/${python.spec.version}")
-            ''
+            '';
           }
           {
             pkg = py-dedalus.withPrefs { version = "2"; };
             projection = "dedalus/{version}-py{^python.version}";
             postscript = ''
               depends_on("python-mpi/${python.spec.version}")
-            ''
+            '';
           }
         ]);
       });
@@ -2027,7 +2027,6 @@ pkgStruct = {
 #  amd/aocl (amdblis, amdlibflame, amdfftw, amdlibm, aocl-sparse, amdscalapack)
 #  amd/uprof
 #  py jaxlib cuda
-#  py deadalus mpi: robert
 
 jupyterBase = pyView (with corePacks.pkgs; [
   python

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -382,6 +382,11 @@ corePacks = import ../packs {
     mpi = {
       name = "openmpi";
     };
+    music = {
+      variants = {
+        hdf5 = true;
+      };
+    };
     nccl = {
       variants = {
         inherit cuda_arch;
@@ -1412,6 +1417,14 @@ pkgStruct = {
     #mplayer
     #mpv
     mupdf
+    {
+      pkg = music.withPrefs {variants = { single_prec = false; }; };
+      projection = "{name}/double-{version}";
+    }
+    {
+      pkg = music.withPrefs {variants = { single_prec = true; }; };
+      projection = "{name}/single-{version}";
+    }
     nccl
     #neovim
     #nix #too old/broken

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -550,6 +550,16 @@ corePacks = import ../packs {
         };
       };
     };
+    py-dedalus = {
+      depends = {
+        fftw = {
+          variants = {
+            mpi = true;
+            precision = ["float" "double" "long_double"];
+          };
+        };
+      };
+    };
     py-distributed = {
       depends = {
         py-tornado = {
@@ -632,6 +642,15 @@ corePacks = import ../packs {
             module = "PyQt5.sip";
           };
           version = "4";
+        };
+      };
+    };
+    py-pytest-cov = {
+      depends = {
+        py-coverage = {
+          variants = {
+            toml = true;
+          };
         };
       };
     };
@@ -1665,6 +1684,22 @@ pkgStruct = {
             triqs-maxent
             #triqs-omegamaxent-interface
             triqs-tprf
+        ] ++
+        [
+          {
+            pkg = py-dedalus.withPrefs { version = "3"; };
+            projection = "dedalus/{version}-py{^python.version}";
+            postscript = ''
+              depends_on("python-mpi/${python.spec.version}")
+            ''
+          }
+          {
+            pkg = py-dedalus.withPrefs { version = "2"; };
+            projection = "dedalus/{version}-py{^python.version}";
+            postscript = ''
+              depends_on("python-mpi/${python.spec.version}")
+            ''
+          }
         ]);
       });
     });

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -131,8 +131,8 @@ corePacks = import ../packs {
       };
     };
     cfitsio = {
-      # for py-astropy
-      version = "3";
+      # for py-astropy and py-fitsio
+      version = "3.49";
     };
     cli11 = {
       # for paraview
@@ -1150,7 +1150,7 @@ mkPythons = base: gen:
 
 pyBlacklist = [
 # { name = "py-pip"; } # already in python
-  { name = "py-setuptools"; } # too many versions
+  { name = "py-setuptools"; version = ":62.5,62.7:"; } # fitsio dep (arbitrary version)
   { name = "py-cython"; version = "0.29.30"; } # py-astropy dep
   { name = "py-cython"; version = "3"; } # py-gevent dep
   { name = "py-flit-core"; version = ":3.2"; } # py-testpath dep
@@ -1669,6 +1669,7 @@ pkgStruct = {
         #py-einsum2
         py-emcee
         py-envisage #qt
+        py-fitsio
         py-flask
         py-flask-socketio
         py-fusepy

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -541,6 +541,15 @@ corePacks = import ../packs {
       # for py-requests
       version = "2.0";
     };
+    py-globus-sdk = {
+      depends = {
+        py-pyjwt = {
+          variants = {
+            crypto = true;
+          };
+        };
+      };
+    };
     py-distributed = {
       depends = {
         py-tornado = {
@@ -1688,6 +1697,8 @@ pkgStruct = {
         py-fusepy
         #py-fuzzysearch
         #py-fwrap
+        py-globus-cli
+        py-globus-sdk
         #py-ggplot
         #py-glueviz
         #py-gmpy2

--- a/fi/repo/packages/fgsl/package.py
+++ b/fi/repo/packages/fgsl/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.pkg.builtin.fgsl as builtin
+from spack.package import *
+
+
+class Fgsl(builtin.Fgsl):
+
+    version("1.5.0",
+        url="https://github.com/reinh-bader/fgsl/archive/1.5.0.tar.gz",
+        sha256="5013b4e000e556daac8b3c83192adfe8f36ffdc91d1d4baf0b1cb3100260e664",
+        )
+
+    # 1.5 works with GSL 2.6, and future versions too, it seems?
+    depends_on("gsl@2.6:", when="@1.5.0")

--- a/fi/repo/packages/py-dedalus/package.py
+++ b/fi/repo/packages/py-dedalus/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyDedalus(PythonPackage):
+    """A flexible framework for solving PDEs with modern spectral methods."""
+
+    homepage = "https://dedalus-project.readthedocs.io"
+
+    version("3.2302-dev",
+        url="https://www.github.com/DedalusProject/dedalus/tarball/5b52e29ab6d5d832de61d412c09e08aa5718e1ab",
+        sha256="fb4788f849a08a575f2033236eef0d35fb1629561ae8a16969dbbc146411cf1e",
+    )
+
+    version("2.2207.3",
+        url="https://pypi.org/packages/source/d/dedalus/dedalus-2.2207.3.tar.gz",
+        sha256="549dc967cfb649ae08c9f891389d74488f34c17850b95127a3f9ed51c758c9ad",
+    )
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-cython@0.22:", type=("build", "run"))
+    depends_on("mpi")
+    depends_on("py-mpi4py@2.0.0:", type=("build", "run"))
+    depends_on("py-numpy@1.20.0:", type=("build", "run"))
+    depends_on("py-docopt", type=("build", "run"))
+    depends_on("py-h5py@2.10.0:", type=("build", "run"), when="@:2")
+    depends_on("py-h5py@3:", type=("build", "run"), when="@3:")
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-py", type=("build", "run"))
+    depends_on("py-pytest", type=("build", "run"))
+    depends_on("py-pytest-benchmark", type=("build", "run"))
+    depends_on("py-pytest-cov", type=("build", "run"))
+    depends_on("py-pytest-parallel", type=("build", "run"))
+    depends_on("py-scipy@1.4.0:", type=("build", "run"))
+    depends_on("py-numexpr", type=("build", "run"), when="@3:")
+    depends_on("py-xarray", type=("build", "run"), when="@3:")
+    depends_on("fftw@3: +mpi", type=("build", "run"))
+
+    def setup_build_environment(self, env):
+        env.set('FFTW_PATH', self.spec['fftw'].prefix)
+        env.set('MPI_PATH', self.spec['mpi'].prefix)

--- a/fi/repo/packages/py-fitsio/package.py
+++ b/fi/repo/packages/py-fitsio/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyFitsio(PythonPackage):
+    """A python package for FITS input/output wrapping cfitsio"""
+
+    homepage = "https://github.com/esheldon/fitsio"
+    pypi = "fitsio/fitsio-1.1.8.tar.gz"
+
+    version("1.1.8", sha256="61f569b2682a0cadce52c9653f0c9b81f951d000522cef645ce1cb49f78300f9")
+
+    depends_on("py-setuptools", type=("build", "run"))
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("cfitsio@3.49", type=("build", "link", "run"))
+
+    def patch(self):
+        filter_file(r'self\.use_system_fitsio =.*',
+                    'self.use_system_fitsio = True',
+                    'setup.py',
+        )
+
+        filter_file(r'self.system_fitsio_includedir =.*',
+                    f'self.system_fitsio_includedir = "{self.spec["cfitsio"].prefix.include}"',
+                    'setup.py'
+        )
+
+        filter_file(r'self.system_fitsio_libdir =.*',
+                    f'self.system_fitsio_libdir = "{self.spec["cfitsio"].prefix.lib}"',
+                    'setup.py'
+        )

--- a/fi/repo/packages/py-globus-cli/package.py
+++ b/fi/repo/packages/py-globus-cli/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyGlobusCli(PythonPackage):
+    """A Command Line Wrapper over the Globus SDK for Python"""
+
+    homepage = "https://github.com/globus/globus-cli"
+    pypi = "globus-cli/globus-cli-3.12.0.tar.gz"
+
+    version("3.12.0", sha256="a93abd8583ea10f6df8fae84e17b5b253b9bb7d563fa09f8eaad0c3a3b8e95eb")
+
+    depends_on("python@3.7:", type=("build", "run"))
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-globus-sdk@3.17.0", type=("build", "run"))
+    depends_on("py-click@8.0.0:8", type=("build", "run"))
+    depends_on("py-jmespath@1.0.1", type=("build", "run"))
+    depends_on("py-packaging@17.0:", type=("build", "run"))
+    depends_on("py-requests@2.19.1:2", type=("build", "run"))
+    # globus-cli specifies py-cryptography@3.3.1:36
+    # but says that this just reflects globus-sdk, which has since removed its upper version limit
+    depends_on("py-cryptography@3.3.1:", type=("build", "run"))
+    depends_on("py-typing-extensions@4.0:", type=("build", "run"), when='python@:3.10')

--- a/fi/repo/packages/py-globus-sdk/package.py
+++ b/fi/repo/packages/py-globus-sdk/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+import spack.pkg.builtin.py_globus_sdk as builtin
+
+
+class PyGlobusSdk(builtin.PyGlobusSdk):
+    """
+    Globus SDK for Python
+    """
+
+    version("3.17.0", sha256="d850b2a88463a0437024734e0a78a49ef896530ec94263b54614ca701960794c")
+
+    depends_on("python@3.7:", type=("build", "run"), when='@3.18:')
+    depends_on("py-typing-extensions@4.0:", when="python@:3.9")

--- a/fi/repo/packages/py-jupyterhub/package.py
+++ b/fi/repo/packages/py-jupyterhub/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+import spack.pkg.builtin.py_jupyterhub as builtin
+
+
+class PyJupyterhub(builtin.PyJupyterhub):
+
+    version("3.1.1", sha256="bfdbc55d7cd29ed2b2c84d2fc7943ad13efdfc4a77740519c5dad1079ff75953")
+
+    depends_on("py-entrypoints", when="@1.0.0:2", type=("build", "run"))
+    depends_on("py-importlib_metadata@3.6:", when="python@:3.9")
+    depends_on("py-packaging")


### PR DESCRIPTION
(Reopening #27 after I accidentally rebased on the wrong branch)

This adds a few relatively simple packages. I think these could reasonable go in the current modules, so the PR is into the fi branch.

One thing I wasn't sure about was whether FGSL should be loading the GSL module automatically. Right now it's not; it just discovers GSL via the rpath. But given that we've had problems with people linking against the system GSL, I wonder if we should add that dependency. I guess this is a more general nixpack question about what Spack dependencies get translated into Lmod dependencies.
