### PR TITLE
fi: nbodykit and dependencies

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1688,6 +1688,7 @@ pkgStruct = {
         py-bottleneck
         py-cachey
         py-cherrypy
+        py-classylss
         py-coverage
         py-cython
         py-dask

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -525,6 +525,11 @@ corePacks = import ../packs {
         };
       };
     };
+    py-bigfile = {
+      variants = {
+        mpi = true;
+      };
+    };
     py-blessings = {
       depends = {
         py-setuptools = {
@@ -1623,6 +1628,7 @@ pkgStruct = {
         /* ---------- python+mpi modules ---------- */
         view = py.packs.pythonView { pkgs = with py.packs.pkgs; [
           py-mpi4py
+          py-bigfile
           py-h5py
         ]; };
         pkgs = lib.optionals (py.isCore && mpi.isCore && lib.versionMatches comp.compiler.spec.version "10:") (with py.packs.pkgs;

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1729,6 +1729,7 @@ pkgStruct = {
         py-mako
         #py-matlab-wrapper
         py-matplotlib
+        py-mcfit
         py-netcdf4
         py-nbconvert
         py-nose

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1644,6 +1644,7 @@ pkgStruct = {
           py-mpi4py
           py-bigfile
           py-h5py
+          py-mpsort
           py-runtests
         ]; };
         pkgs = lib.optionals (py.isCore && mpi.isCore && lib.versionMatches comp.compiler.spec.version "10:") (with py.packs.pkgs;

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1645,6 +1645,8 @@ pkgStruct = {
           py-bigfile
           py-h5py
           py-mpsort
+          py-pfft-python
+          py-pmesh
           py-runtests
         ]; };
         pkgs = lib.optionals (py.isCore && mpi.isCore && lib.versionMatches comp.compiler.spec.version "10:") (with py.packs.pkgs;

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1797,6 +1797,8 @@ pkgStruct = {
         py-torchvision
       ] ++ lib.optionals (lib.versionMatches py.python.version ":3.9") [
         py-psycopg2
+      ] ++ lib.optionals (lib.versionMatches py.python.version "3.9:") [
+        py-halotools
       ])
       ).overrideView {
         ignoreConflicts = [

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1648,6 +1648,7 @@ pkgStruct = {
           py-pfft-python
           py-pmesh
           py-runtests
+          py-nbodykit
         ]; };
         pkgs = lib.optionals (py.isCore && mpi.isCore && lib.versionMatches comp.compiler.spec.version "10:") (with py.packs.pkgs;
           [(pkgMod triqs // {

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1723,6 +1723,7 @@ pkgStruct = {
         py-jupyter-server
         py-jupyterlab
         py-jupyterlab-server
+        py-kdcount
         #py-leveldb
         #py-llfuse
         py-mako
@@ -1771,6 +1772,7 @@ pkgStruct = {
         py-seaborn
         #py-setuptools
         py-shapely
+        py-sharedmem
         #py-sip
         py-sphinx
         py-sqlalchemy

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -626,6 +626,20 @@ corePacks = import ../packs {
         };
       };
     };
+    py-pytest-cov = {
+      depends = {
+        py-coverage = {
+          variants = {
+            toml = true;
+          };
+        };
+      };
+    };
+    py-runtests = {
+      variants = {
+        mpi = true;
+      };
+    };
     py-scikit-image = {
       depends = {
         py-setuptools = {
@@ -1630,6 +1644,7 @@ pkgStruct = {
           py-mpi4py
           py-bigfile
           py-h5py
+          py-runtests
         ]; };
         pkgs = lib.optionals (py.isCore && mpi.isCore && lib.versionMatches comp.compiler.spec.version "10:") (with py.packs.pkgs;
           [(pkgMod triqs // {
@@ -1669,6 +1684,7 @@ pkgStruct = {
         py-bokeh
         py-bottleneck
         py-cherrypy
+        py-coverage
         py-cython
         py-dask
         #py-deeptools #pysam broken

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1689,6 +1689,7 @@ pkgStruct = {
         py-cachey
         py-cherrypy
         py-classylss
+        py-corrfunc
         py-coverage
         py-cython
         py-dask

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1686,6 +1686,7 @@ pkgStruct = {
         py-biopython
         py-bokeh
         py-bottleneck
+        py-cachey
         py-cherrypy
         py-coverage
         py-cython

--- a/fi/repo/packages/py-bigfile/package.py
+++ b/fi/repo/packages/py-bigfile/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBigfile(PythonPackage):
+    """A reproducible massively parallel IO library for hierarchical data"""
+
+    homepage = "https://github.com/rainwoodman/bigfile"
+    pypi = "bigfile/bigfile-0.1.51.tar.gz"
+
+    version("0.1.51", sha256="1fad962defc7a5dff2965025dff9a3efa23594e1c2300de0c9a43940d4717b65")
+
+    variant("mpi", default=True, description="MPI support")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+
+    depends_on("mpi", when="+mpi")
+    depends_on("py-mpi4py", type=("build", "run"), when="+mpi")

--- a/fi/repo/packages/py-cachey/package.py
+++ b/fi/repo/packages/py-cachey/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCachey(PythonPackage):
+    """Caching based on computation time and storage space"""
+
+    homepage = "https://github.com/dask/cachey"
+    pypi = "cachey/cachey-0.2.1.tar.gz"
+
+    version("0.2.1", sha256="0310ba8afe52729fa7626325c8d8356a8421c434bf887ac851e58dcf7cf056a6")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-heapdict", type=("build", "run"))
+    
+    depends_on("py-pytest", type=("test"))
+    depends_on("py-pytest-runner", type=("test"))

--- a/fi/repo/packages/py-classylss/package.py
+++ b/fi/repo/packages/py-classylss/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyClassylss(PythonPackage):
+    """a lightweight Python binding of the CLASS CMB Boltzmann code"""
+
+    homepage = "https://github.com/nickhand/classylss"
+    pypi = "classylss/classylss-0.2.9.tar.gz"
+
+    version("0.2.9", sha256="1a8521d2bf9da3d2572245e801e243fcf76f7518b59cbe525a31aa80a884dd86")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("py-six", type=("build", "run"))
+
+    def patch(self):
+        # Shouldn't rely on the Cythonized output being portable
+        remove('classylss/binding.c')

--- a/fi/repo/packages/py-corrfunc/package.py
+++ b/fi/repo/packages/py-corrfunc/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyCorrfunc(PythonPackage):
+    """Blazing fast correlation functions on the CPU"""
+
+    homepage = "https://corrfunc.readthedocs.io/"
+    pypi = "Corrfunc/Corrfunc-2.5.0.tar.gz"
+
+    maintainers("lgarrison")
+
+    version("2.5.0", sha256="91c41ef0266daf644ba19ecd9d536a82018bd0d596854f0607d9e7485cfcfb95")
+
+    depends_on("python@3.5:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+
+    depends_on("gmake")
+    depends_on("py-numpy@1.7:", type=("build", "run"))
+    depends_on("py-future", type=("build", "run"))
+    depends_on("py-wurlitzer", type=("build", "run"))
+    depends_on("gsl@2.4:", type=("build", "run"))
+
+    def patch(self):
+        filter_file(
+            '-march=native',
+            '',
+            'common.mk'
+        )
+
+    def global_options(self, spec, prefix):
+        options = ['CC=cc']
+        return options

--- a/fi/repo/packages/py-halotools/package.py
+++ b/fi/repo/packages/py-halotools/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHalotools(PythonPackage):
+    """Python package for studying large scale structure, cosmology, and galaxy
+    evolution using N-body simulations and halo models"""
+
+    homepage = "https://halotools.readthedocs.io/"
+    pypi = "halotools/halotools-0.8.1.tar.gz"
+
+    version("0.8.1", sha256="defc8913f06e2bf69ca33b4167eb61fa5277810a5daedd1b84846186061a78e3")
+
+    variant("extras", default=True, description="Install the 'all' set of extras")
+
+    depends_on("python@3.9:", type=("build", "run"))
+
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm", type="build")
+    # depends_on("py-oldest-supported-numpy", type="build")
+    depends_on("py-cython@0.29.32", type="build")
+    depends_on("py-extension-helpers", type="build")
+
+    depends_on("py-astropy", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-requests", type=("build", "run"))
+    depends_on("py-beautifulsoup4", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+
+    depends_on("py-h5py", type=("build", "run"), when="+extras")

--- a/fi/repo/packages/py-kdcount/package.py
+++ b/fi/repo/packages/py-kdcount/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyKdcount(PythonPackage):
+    """ KDTree for low dimensional spatial indexing, a Python extension"""
+
+    homepage = "https://github.com/rainwoodman/kdcount"
+
+    version("0.3.29-13-g6e6ddfc",
+        url='https://github.com/rainwoodman/kdcount/tarball/6e6ddfcd17621ef0e42a4ea7360e87613ddbee33',
+        sha256="f4cc85cbb61a0b2f50f1162b113b12f5c4d5b159e6c9ecd15d0ae4ad6fa17838",
+    )
+
+    variant('sharedmem', default=True, description='Use sharedmem')
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("py-sharedmem", type=("build", "run"), when='+sharedmem')

--- a/fi/repo/packages/py-mcfit/package.py
+++ b/fi/repo/packages/py-mcfit/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMcfit(PythonPackage):
+    """multiplicatively convolutional fast integral transforms"""
+
+    homepage = "https://github.com/eelregit/mcfit"
+    pypi = "mcfit/mcfit-0.0.18.tar.gz"
+
+    version("0.0.18", sha256="2d2564b4f511c7101caf1d06947927140ef2068175a42c966d0844c7ddb9914c")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-mpmath", type=("build", "run"))

--- a/fi/repo/packages/py-mpsort/package.py
+++ b/fi/repo/packages/py-mpsort/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyMpsort(PythonPackage):
+    """Massively Parallel Histogram Sort"""
+
+    homepage = "https://github.com/rainwoodman/MP-sort"
+
+    version("0.1.17-56-gea7a5bf",
+        url='https://github.com/rainwoodman/MP-sort/tarball/ea7a5bfd24d2fa9fe2de7ede5946f2c6761229b6',
+        sha256="d8ead1f88cbaea9aac4d5b67c938ed3ddc611f6ba1577dcc739ad92ed0ec6d89",
+    )
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("mpi")
+    depends_on("py-mpi4py", type=("build", "run"))

--- a/fi/repo/packages/py-nbodykit/package.py
+++ b/fi/repo/packages/py-nbodykit/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyNbodykit(PythonPackage):
+    """ Analysis kit for large-scale structure datasets, the massively parallel way"""
+
+    homepage = "https://nbodykit.readthedocs.io"
+
+    version("0.3.15-40-g376c9d78",
+        url='https://www.github.com/bccp/nbodykit/tarball/376c9d78204650afd9af81d148b172804432c02f',
+        sha256="2a38ab2dd78893a542997af168bba57794e1916efbd5d436b0507487ae383dc5",
+    )
+
+    variant('extras', default=True, description='Install extras')
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("mpi")
+    depends_on("py-mpi4py", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-astropy", type=("build", "run"))
+    depends_on("py-pyerfa", type=("build", "run"))
+    depends_on("py-six", type=("build", "run"))
+    depends_on("py-runtests +mpi", type=("build", "run"))
+    depends_on("py-pmesh", type=("build", "run"))
+    depends_on("py-kdcount", type=("build", "run"))
+    depends_on("py-mpsort", type=("build", "run"))
+    depends_on("py-bigfile +mpi", type=("build", "run"))
+    depends_on("py-pandas", type=("build", "run"))
+    depends_on("py-dask@0.14.2:", type=("build", "run"))
+    depends_on("py-cachey", type=("build", "run"))
+    depends_on("py-sympy@1.6.2:", type=("build", "run"))
+    depends_on("py-numexpr", type=("build", "run"))
+    depends_on("py-corrfunc", type=("build", "run"))
+    depends_on("py-mcfit", type=("build", "run"))
+    depends_on("py-classylss@0.2:", type=("build", "run"))
+
+    depends_on('py-halotools', type=("build", "run"), when='+extras ^python@3.9:')
+    depends_on('py-h5py', type=("build", "run"), when='+extras')
+    depends_on('py-fitsio', type=("build", "run"), when='+extras')

--- a/fi/repo/packages/py-pfft-python/package.py
+++ b/fi/repo/packages/py-pfft-python/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPfftPython(PythonPackage):
+    """python binding of PFFT, a massively parallel FFT library"""
+
+    homepage = "https://github.com/rainwoodman/pfft-python"
+    pypi = "pfft-python/pfft-python-0.1.21.tar.gz"
+
+    version("0.1.21", sha256="2c5bf26170dffbe06c897f1edbbcf35961baf48fb3a383eedcc3103648e4d334")
+
+    depends_on("py-setuptools", type="build")
+    
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("mpi")
+    # Need to use the bundled, patched pfft (which in turn bundles FFTW)
+    # depends_on("pfft", type=("build", "link", "run"))
+    depends_on("py-mpi4py", type=("build", "run"))
+    depends_on("py-cython", type=("build", "run"))
+
+    def patch(self):
+        # removing cythonized file from sdist
+        remove('pfft/core.c')
+
+        if 'sse' not in self.spec.target:
+            filter_file(r"optimize=.*sse.*",
+                        "optimize=''",
+                        'setup.py',
+            )

--- a/fi/repo/packages/py-pmesh/package.py
+++ b/fi/repo/packages/py-pmesh/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+
+class PyPmesh(PythonPackage):
+    """Particle Mesh in Python"""
+
+    homepage = "https://github.com/rainwoodman/pmesh"
+
+    version("0.1.56-7-g6fe8b2d",
+        url='https://github.com/rainwoodman/pmesh/tarball/6fe8b2da4a3fd408517ff16698da0eac05b8cd13',
+        sha256="65ab0a89f894f6a41059cc07307c6d98fe0946ae3a3fd45e2b697094f8f3aa5f",
+    )
+
+    variant("abopt", default=False, description="Add support for abopt")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-cython", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("mpi")
+    depends_on("py-mpi4py", type=("build", "run"))
+    depends_on("py-mpsort", type=("build", "run"))
+    depends_on("py-pfft-python", type=("build", "run"))
+
+    depends_on('py-abopt', type=("build", "run"), when="+abopt")

--- a/fi/repo/packages/py-runtests/package.py
+++ b/fi/repo/packages/py-runtests/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyRuntests(PythonPackage):
+    """Simple testing of fresh package builds using pytest, with optional mpi4py support"""
+
+    homepage = "https://github.com/bccp/runtests"
+    pypi = "runtests/runtests-0.0.28.tar.gz"
+
+    version("0.0.28", sha256="add28a6cbbf4cdcfcabb0a8897f154835b7357c0c502e4a389829d30c2dabee4")
+
+    variant("mpi", default=True, description="MPI support")
+
+    depends_on("py-setuptools", type="build")
+    
+    depends_on("py-pytest", type=("build", "run"))
+    depends_on("py-coverage", type=("build", "run"))
+    
+    depends_on("mpi", when="+mpi")
+    depends_on("py-mpi4py", type=("build", "run"), when="+mpi")

--- a/fi/repo/packages/py-sharedmem/package.py
+++ b/fi/repo/packages/py-sharedmem/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PySharedmem(PythonPackage):
+    """A different flavor of multiprocessing in Python"""
+
+    homepage = "https://github.com/rainwoodman/sharedmem"
+    pypi = "sharedmem/sharedmem-0.3.8.tar.gz"
+
+    version("0.3.8", sha256="c654a6bee2e2f35c82e6cc8b6c262fcabd378f5ba11ac9ef71530f8dabb8e2f7")
+
+    depends_on("py-setuptools", type="build")
+
+    depends_on("py-numpy", type=("build", "run"))


### PR DESCRIPTION
Adds nbodykit, which is a python-mpi package that itself depends on many python and python-mpi packages. The build systems for many of these packages are very old, but ultimately most just required small tweaks to get to a satisfactory state.

The exception is pfft-python, which downloads a patched fork of pfft during installation. The patched fork itself bundles FFTW; it's pretty deeply integrated and breaking pfft and FFTW out into proper Spack dependencies did not seem easy. The installation seems to go smoothly, though, so I opted to just let pfft-python do this.

I tested the Python packages by importing them, and running pytest on them where applicable.