### PR TITLE
fi: scalapack

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -980,7 +980,6 @@ bootstrapPacks = corePacks.withPrefs {
 blasVirtuals = blas: {
   blas      = blas;
   lapack    = blas;
-  scalapack = blas;
 };
 
 cuda_arch = { none = false; } // builtins.listToAttrs
@@ -1651,6 +1650,8 @@ pkgStruct = {
           gromacs
           { pkg = gromacs.withPrefs { version = "2022.3"; variants = { plumed = true; }; };
             projection = "{name}/mpi-plumed-{version}"; }
+          { pkg = netlib-scalapack;  # MKL provies Intel ScaLAPACK
+            projection = "scalapack/{version}"; }
           plumed
           #(relion.withPrefs { version = "3"; })
           (relion.withPrefs { version = "4"; })


### PR DESCRIPTION
`netlib-scalapack` seemed to build without any issues. It links against flexiblas. I haven't tested it at all, though.

I added this an an MPI library, but only for the core compiler and core MPI, since if you want to use ScaLAPACK with the Intel compiler, then you're probably better off with MKL.