### PR TITLE
honor enableParallelBuilding to set NIX_BUILD_CORES=1

### DIFF
--- a/spack/nixpack.py
+++ b/spack/nixpack.py
@@ -64,7 +64,10 @@ spack.config.config.remove_scope('system')
 spack.config.config.remove_scope('user')
 
 spack.config.set('config:build_stage', [getVar('NIX_BUILD_TOP')], 'command_line')
-cores = int(getVar('NIX_BUILD_CORES', 0))
+enableParallelBuilding = bool(getVar('enableParallelBuilding', True))
+cores = 1
+if enableParallelBuilding:
+    cores = int(getVar('NIX_BUILD_CORES', 0))
 if cores > 0:
     spack.config.set('config:build_jobs', cores, 'command_line')
 


### PR DESCRIPTION
This allows to compile package sequentially by setting

package.$name.build.enableParallelBuilding=false;