### PR TITLE
fi: cudnn: make meta-module to select cudnn version for cuda 11 or 12

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1134,6 +1134,8 @@ format_cudaarch = (dot: sep: builtins.concatStringsSep sep
   )
 );
 
+cudnn-meta-ver = "${builtins.elemAt (lib.splitRegex "-" corePacks.pkgs.cudnn.spec.version) 0}";
+
 mkSkylake = base: base.withPrefs {
   global = {
     target = "skylake_avx512";
@@ -1516,12 +1518,16 @@ pkgStruct = {
     { pkg = cuda;
       default = true;
       postscript = ''
-        load("cudnn")
+        if ( isloaded("cudnn") ) then
+          load("cudnn/${cudnn-meta-ver}")
+        end
       '';
     }
     { pkg = (mkCuda12 corePacks).pkgs.cuda;
       postscript = ''
-        load("cudnn")
+        if ( isloaded("cudnn") ) then
+          load("cudnn/${cudnn-meta-ver}")
+        end
       '';
     }
     { pkg = cudnn;
@@ -2187,15 +2193,15 @@ pkgStruct = {
     }
 
     { name = "cudnn";
-      version = builtins.elemAt (lib.splitRegex "-" corePacks.pkgs.cudnn.spec.version) 0;
+      version = cudnn-meta-ver;
       default = true;
       postscript = ''
       whatis("Short description: cudnn meta-module that selects the version appropriate for the loaded cuda")
       help([[cudnn meta-module that selects the version appropriate for the loaded cuda]])
       if ( isloaded("cuda/12.1.1") ) then
-        load("cudnn/8.9.2.26-12.x")
+        load("cudnn/${cudnn-meta-ver}-12.x")
       else
-        load("cudnn/8.9.2.26-11.x")
+        load("cudnn/${cudnn-meta-ver}-11.x")
       end
       '';
     }

--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1513,13 +1513,19 @@ pkgStruct = {
     blast-plus
     #blender
     cmake
-    { pkg = cuda; default = true; }
-    (mkCuda12 corePacks).pkgs.cuda
-    { pkg = cudnn;
+    { pkg = cuda;
       default = true;
       postscript = ''
-        depends_on("cuda/11")
+        load("cudnn")
       '';
+    }
+    { pkg = (mkCuda12 corePacks).pkgs.cuda;
+      postscript = ''
+        load("cudnn")
+      '';
+    }
+    { pkg = cudnn;
+      default = false;
     }
     { pkg = cudnn.withPrefs {
         version = "8.9.2.26-12.x";
@@ -1529,9 +1535,7 @@ pkgStruct = {
           };
         };
       };
-      postscript = ''
-        depends_on("cuda/12")
-      '';
+      default = false;
     }
     curl
     disBatch
@@ -2180,6 +2184,20 @@ pkgStruct = {
           hide_version("${n.spec.name}/${n.spec.version}")
         '') (with corePacks.pkgs; [ ilmbase openexr ]))
         ;
+    }
+
+    { name = "cudnn";
+      version = builtins.elemAt (lib.splitRegex "-" corePacks.pkgs.cudnn.spec.version) 0;
+      default = true;
+      postscript = ''
+      whatis("Short description: cudnn meta-module that selects the version appropriate for the loaded cuda")
+      help([[cudnn meta-module that selects the version appropriate for the loaded cuda]])
+      if ( isloaded("cuda/12.1.1") ) then
+        load("cudnn/8.9.2.26-12.x")
+      else
+        load("cudnn/8.9.2.26-11.x")
+      end
+      '';
     }
   ];
 


### PR DESCRIPTION
In this version, the `cuda` modules load the `cudnn` meta-module automatically to ensure the correct `cudnn` gets loaded if the cuda module is swapped (i.e. it enforces hierarchy-like behavior).

It's still possible for a user to shoot themselves in the foot by directly loading the wrong `cudnn` after loading `cuda`, but this should cover the majority of cases.