### PR TITLE
nixpkgs: force patchelf to always use rpath

### DIFF
--- a/nixpkgs/overlay.nix
+++ b/nixpkgs/overlay.nix
@@ -4,6 +4,12 @@ with pkgs;
 {
   nss_sss = callPackage sssd/nss-client.nix { };
 
+  patchelf = patchelf.overrideAttrs (old: {
+    postPatch = ''
+      sed -i 's/static bool forceRPath = false;/static bool forceRPath = true;/' src/patchelf.cc
+    '';
+  });
+
   makeShellWrapper = makeShellWrapper.overrideAttrs (old: {
     # avoid infinite recursion by escaping to system (hopefully it's good enough)
     shell = "/bin/sh";

--- a/nixpkgs/overlay.nix
+++ b/nixpkgs/overlay.nix
@@ -8,6 +8,7 @@ with pkgs;
     postPatch = ''
       sed -i 's/static bool forceRPath = false;/static bool forceRPath = true;/' src/patchelf.cc
     '';
+    doCheck = false;
   });
 
   makeShellWrapper = makeShellWrapper.overrideAttrs (old: {


### PR DESCRIPTION
This effectively makes nix only use rpath rather than runpath. It's not perfect, since it doesn't change things that don't use patchelf (and just link), but it seems to fix the important cases.