### PR TITLE
avoid full rebuild

### DIFF
--- a/packs/default.nix
+++ b/packs/default.nix
@@ -124,7 +124,7 @@ lib.fix (packs: with packs; {
       then if attrs.withRepos
         then repos
         else null
-      else map (r: r + "/repo.yaml") repos;
+      else map (r: (builtins.path { path=r + "/repo.yaml";})) repos;
     spackCache = if attrs.withRepos or false then spackCacheRepos else spackCache;
   } // attrs)) ["PYTHONPATH" "PATH" "LC_ALL" "spackConfig" "spackCache" "passAsFile"];
 
@@ -299,7 +299,7 @@ lib.fix (packs: with packs; {
           spec = builtins.toJSON spec;
           passAsFile = ["spec"];
           repoPkgs = map (r: let p = r + "/packages/${pname}"; in
-            lib.when (builtins.pathExists p) p) repos;
+            lib.when (builtins.pathExists p) (builtins.path { name="repo-pkgs-${pname}"; path=p; })) repos;
         } // desc.build // pprefs.build or {}) // {
           inherit spec;
           withPrefs = p: resolvePackage pname gen (lib.prefsUpdate pprefs p);

--- a/packs/default.nix
+++ b/packs/default.nix
@@ -124,8 +124,8 @@ lib.fix (packs: with packs; {
       then if attrs.withRepos
         then repos
         else null
-      else map (r: (builtins.path { path=r + "/repo.yaml";})) repos;
-    spackCache = if attrs.withRepos or false then spackCacheRepos else spackCache;
+      else map (r: (builtins.path { name="repo.yaml"; path=r + "/repo.yaml";})) repos;
+    #spackCache = if attrs.withRepos or false then spackCacheRepos else spackCache;
   } // attrs)) ["PYTHONPATH" "PATH" "LC_ALL" "spackConfig" "spackCache" "passAsFile"];
 
   /* pre-generated spack repo index cache (both with and without overlay repos) */
@@ -137,8 +137,8 @@ lib.fix (packs: with packs; {
       inherit withRepos;
     }));
 
-  spackCache      = makeSpackCache false;
-  spackCacheRepos = makeSpackCache true;
+  #spackCache      = makeSpackCache false;
+  #spackCacheRepos = makeSpackCache true;
 
   isVirtual = name: builtins.isList repo.${name} or null;
 


### PR DESCRIPTION
This solves https://github.com/flatironinstitute/nixpack/issues/42 but this also requires (only if you want to avoid the full rebuild) to add a second spack repo (spackPkgs for example) and add `${spackPkgs}/var/spack/repos/builtin` to the `repo` argument of packs.