### PR TITLE
fi: build python with optimizations

### DIFF
--- a/fi/default.nix
+++ b/fi/default.nix
@@ -1536,6 +1536,7 @@ mkPython = base: version:
       inherit version;
       variants = {
         tkinter = true; # break dependency cycle
+        optimizations = true;
       };
     }; in {
     python = python;


### PR DESCRIPTION
Increases the build time from 1 minute to 8 minutes on my workstation, so maybe 15 minutes on the nixpack build machines. That might be annoying during development, so I'm making a PR to remind us to add it closer to the modules release.

`+optimizations` enables a few enhancements like PGO and LTO. python-build-standalone includes these, so it would be a shame if modules Python didn't also.